### PR TITLE
feat(M0-03): add engine scaffolding

### DIFF
--- a/completions.txt
+++ b/completions.txt
@@ -1,6 +1,6 @@
 M0-01 DONE 2025-08-21 01:13 - Vite+TS scaffold
 M0-02 DONE 2025-08-21 01:19 - Canvas bootstrap and game loop
-M0-03 TODO 0000-00-00 00:00 -
+M0-03 DONE 2025-08-21 01:25 - engine core with scene switching and RNG
 M0-04 TODO 0000-00-00 00:00 -
 M0-05 TODO 0000-00-00 00:00 -
 M0-06 TODO 0000-00-00 00:00 -

--- a/notes.txt
+++ b/notes.txt
@@ -1,2 +1,3 @@
 - M0-01: Scaffolded Vite + TypeScript project with ESLint and Prettier. Cloudflare Pages deployment planned.
 - M0-02: Added canvas bootstrap and basic game loop.
+- M0-03: Introduced Game engine with scene management, render helpers, and seeded RNG.

--- a/src/engine/game.ts
+++ b/src/engine/game.ts
@@ -1,0 +1,39 @@
+import { Rng } from './rng';
+import { clear } from './render';
+
+export interface Scene {
+  update(delta: number, rng: Rng): void;
+  draw(context: CanvasRenderingContext2D): void;
+}
+
+export class Game {
+  private context: CanvasRenderingContext2D;
+  private current: Scene;
+  private previous: number;
+  readonly rng: Rng;
+
+  constructor(context: CanvasRenderingContext2D, initial: Scene, seed: number) {
+    this.context = context;
+    this.current = initial;
+    this.previous = performance.now();
+    this.rng = new Rng(seed);
+    this.loop = this.loop.bind(this);
+  }
+
+  start(): void {
+    requestAnimationFrame(this.loop);
+  }
+
+  switchScene(scene: Scene): void {
+    this.current = scene;
+  }
+
+  private loop(timestamp: number): void {
+    const delta = (timestamp - this.previous) / 1000;
+    this.previous = timestamp;
+    this.current.update(delta, this.rng);
+    clear(this.context);
+    this.current.draw(this.context);
+    requestAnimationFrame(this.loop);
+  }
+}

--- a/src/engine/render.ts
+++ b/src/engine/render.ts
@@ -1,0 +1,13 @@
+export function clear(context: CanvasRenderingContext2D): void {
+  context.clearRect(0, 0, context.canvas.width, context.canvas.height);
+}
+
+export function drawText(
+  context: CanvasRenderingContext2D,
+  text: string,
+  x: number,
+  y: number
+): void {
+  context.fillStyle = 'white';
+  context.fillText(text, x, y);
+}

--- a/src/engine/rng.ts
+++ b/src/engine/rng.ts
@@ -1,0 +1,12 @@
+export class Rng {
+  private value: number;
+
+  constructor(seed: number) {
+    this.value = seed;
+  }
+
+  next(): number {
+    this.value = (1664525 * this.value + 1013904223) % 0xffffffff;
+    return this.value / 0xffffffff;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,29 @@
+import { Game, Scene } from './engine/game';
+import type { Rng } from './engine/rng';
+import { drawText } from './engine/render';
+
+class DemoScene implements Scene {
+  private x: number;
+
+  constructor() {
+    this.x = 20;
+  }
+
+  update(delta: number, rng: Rng): void {
+    const step = rng.next() * 60;
+    this.x = this.x + step * delta;
+    if (this.x > 100) {
+      this.x = 20;
+    }
+  }
+
+  draw(context: CanvasRenderingContext2D): void {
+    context.fillStyle = 'white';
+    context.fillRect(this.x, 20, 20, 20);
+    drawText(context, 'Demo', 20, 60);
+  }
+}
+
 function start(): void {
   const element = document.getElementById('game');
   if (element === null) {
@@ -19,26 +45,9 @@ function start(): void {
   resize();
   window.addEventListener('resize', resize);
 
-  let previous = performance.now();
-
-  function update(delta: number): void {
-    Math.sin(delta);
-  }
-
-  function draw(): void {
-    context.clearRect(0, 0, canvas.width, canvas.height);
-    // draw game state
-  }
-
-  function loop(timestamp: number): void {
-    const delta = (timestamp - previous) / 1000;
-    previous = timestamp;
-    update(delta);
-    draw();
-    requestAnimationFrame(loop);
-  }
-
-  requestAnimationFrame(loop);
+  const scene = new DemoScene();
+  const game = new Game(context, scene, 1);
+  game.start();
 }
 
 start();


### PR DESCRIPTION
## Summary
- add deterministic RNG helper
- implement Game with scene switching and render clearing
- wire demo scene using render helpers and RNG

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a674f9f32c832d85acfe61816c1a1b