### PR TITLE
feat(M0-04): add global game state

### DIFF
--- a/completions.txt
+++ b/completions.txt
@@ -1,7 +1,7 @@
 M0-01 DONE 2025-08-21 01:13 - Vite+TS scaffold
 M0-02 DONE 2025-08-21 01:19 - Canvas bootstrap and game loop
 M0-03 DONE 2025-08-21 01:25 - engine core with scene switching and RNG
-M0-04 TODO 0000-00-00 00:00 -
+M0-04 DONE 2025-08-21 01:33 - global game state skeleton
 M0-05 TODO 0000-00-00 00:00 -
 M0-06 TODO 0000-00-00 00:00 -
 M0-07 TODO 0000-00-00 00:00 -

--- a/notes.txt
+++ b/notes.txt
@@ -1,3 +1,4 @@
 - M0-01: Scaffolded Vite + TypeScript project with ESLint and Prettier. Cloudflare Pages deployment planned.
 - M0-02: Added canvas bootstrap and basic game loop.
 - M0-03: Introduced Game engine with scene management, render helpers, and seeded RNG.
+- M0-04: Added global game state store and basic zone display.

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { Game, Scene } from './engine/game';
 import type { Rng } from './engine/rng';
 import { drawText } from './engine/render';
+import { gameState } from './state/gameState';
 
 class DemoScene implements Scene {
   private x: number;
@@ -21,6 +22,8 @@ class DemoScene implements Scene {
     context.fillStyle = 'white';
     context.fillRect(this.x, 20, 20, 20);
     drawText(context, 'Demo', 20, 60);
+    const zoneText = 'Zone: ' + gameState.currentZone;
+    drawText(context, zoneText, 20, 80);
   }
 }
 

--- a/src/state/gameState.ts
+++ b/src/state/gameState.ts
@@ -1,0 +1,14 @@
+import type { GameState } from './types';
+
+export const gameState: GameState = {
+  player: {
+    hp: 100,
+    pennies: 0,
+    inventory: [],
+  },
+  currentZone: 'picnic_table',
+  flags: {
+    flyKills: 0,
+    zoneUnlocks: ['picnic_table'],
+  },
+};

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -1,0 +1,22 @@
+export interface ItemInstance {
+  id: string;
+  quantity: number;
+  durability?: number;
+}
+
+export interface PlayerState {
+  hp: number;
+  pennies: number;
+  inventory: ItemInstance[];
+}
+
+export interface GameFlags {
+  flyKills: number;
+  zoneUnlocks: string[];
+}
+
+export interface GameState {
+  player: PlayerState;
+  currentZone: string;
+  flags: GameFlags;
+}


### PR DESCRIPTION
## Summary
- define shared game state types
- add global state store and initial values
- display current zone using shared state

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a675f6fc18832d966b5e76b44f2739