### PR TITLE
feat(M0-05): add content schema validators

### DIFF
--- a/completions.txt
+++ b/completions.txt
@@ -2,7 +2,7 @@ M0-01 DONE 2025-08-21 01:13 - Vite+TS scaffold
 M0-02 DONE 2025-08-21 01:19 - Canvas bootstrap and game loop
 M0-03 DONE 2025-08-21 01:25 - engine core with scene switching and RNG
 M0-04 DONE 2025-08-21 01:33 - global game state skeleton
-M0-05 TODO 0000-00-00 00:00 -
+M0-05 DONE 2025-08-21 01:34 - Added Zod content schemas
 M0-06 TODO 0000-00-00 00:00 -
 M0-07 TODO 0000-00-00 00:00 -
 M0-08 TODO 0000-00-00 00:00 -

--- a/notes.txt
+++ b/notes.txt
@@ -2,3 +2,4 @@
 - M0-02: Added canvas bootstrap and basic game loop.
 - M0-03: Introduced Game engine with scene management, render helpers, and seeded RNG.
 - M0-04: Added global game state store and basic zone display.
+- M0-05: Implemented Zod validators for content schemas.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "defenderof",
       "version": "0.1.0",
+      "dependencies": {
+        "zod": "^3.25.76"
+      },
       "devDependencies": {
         "@types/node": "^24.3.0",
         "@typescript-eslint/eslint-plugin": "^8.40.0",
@@ -2903,6 +2906,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.40.0",
     "vite": "^7.1.3"
+  },
+  "dependencies": {
+    "zod": "^3.25.76"
   }
 }

--- a/src/content/schema.ts
+++ b/src/content/schema.ts
@@ -1,0 +1,112 @@
+import { z } from 'zod';
+
+export const CurrencySchema = z.object({
+  pennies: z.number().int().nonnegative().optional(),
+});
+
+export const EnemySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  hp: z.number().nonnegative(),
+  damagePerHit: z.number().nonnegative(),
+  onHitPlayer: z.object({
+    flat: z.number().nonnegative(),
+    dot: z.number().nonnegative(),
+  }),
+  bounty: CurrencySchema,
+  tags: z.array(z.string()),
+  behaviors: z
+    .object({
+      enragedMultiplier: z.number().nonnegative().optional(),
+    })
+    .partial()
+    .optional(),
+});
+
+export type Enemy = z.infer<typeof EnemySchema>;
+
+export const ItemSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  type: z.string(),
+  damage: z.number(),
+  cooldownMs: z.number(),
+  durability: z.number().optional(),
+  consumable: z.boolean(),
+  requirements: z.array(z.string()),
+  effects: z.record(z.any()).optional(),
+});
+
+export type Item = z.infer<typeof ItemSchema>;
+
+export const ActionSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  cooldownMs: z.number(),
+  requires: z.array(z.string()),
+  exec: z.string(),
+  params: z.record(z.any()).optional(),
+  postUnlock: z
+    .object({
+      onItemOwned: z.string().optional(),
+      newCooldownMs: z.number().optional(),
+    })
+    .optional(),
+});
+
+export type Action = z.infer<typeof ActionSchema>;
+
+export const PesterSchema = z.object({
+  id: z.string(),
+  target: z.string(),
+  threshold: z.number(),
+  increments: z.object({
+    '1': z.number(),
+    '2': z.number(),
+    '3': z.number(),
+    '0': z.number().optional(),
+  }),
+  reward: z.object({ grantItem: z.string().optional() }).optional(),
+});
+
+export type Pester = z.infer<typeof PesterSchema>;
+
+export const BossSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    hp: z.number(),
+    immunities: z.array(z.string()),
+  })
+  .catchall(z.any());
+
+export type Boss = z.infer<typeof BossSchema>;
+
+const ZoneRewardsSchema = z.object({
+  unlock: z.array(z.string()),
+});
+
+export const ZoneSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  enemies: z.array(z.string()),
+  actions: z.array(z.string()),
+  store: z.string(),
+  bosses: z.array(z.string()),
+  rewards: ZoneRewardsSchema.optional(),
+});
+
+export type Zone = z.infer<typeof ZoneSchema>;
+
+const StoreItemSchema = z.object({
+  itemId: z.string(),
+  cost: CurrencySchema,
+  lockedUntil: z.string().optional(),
+});
+
+export const StoreSchema = z.object({
+  id: z.string(),
+  items: z.array(StoreItemSchema),
+});
+
+export type Store = z.infer<typeof StoreSchema>;


### PR DESCRIPTION
## Summary
- add Zod validators for core content types
- track M0-05 completion and notes
- install zod dependency

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a676c9f204832da543541f9f46cf7c