### PR TITLE
feat(M0-06): add zone and item content

### DIFF
--- a/completions.txt
+++ b/completions.txt
@@ -3,7 +3,7 @@ M0-02 DONE 2025-08-21 01:19 - Canvas bootstrap and game loop
 M0-03 DONE 2025-08-21 01:25 - engine core with scene switching and RNG
 M0-04 DONE 2025-08-21 01:33 - global game state skeleton
 M0-05 DONE 2025-08-21 01:34 - Added Zod content schemas
-M0-06 TODO 0000-00-00 00:00 -
+M0-06 DONE 2025-08-21 01:42 - Added initial content JSON and tuning
 M0-07 TODO 0000-00-00 00:00 -
 M0-08 TODO 0000-00-00 00:00 -
 M0-09 TODO 0000-00-00 00:00 -

--- a/content/bosses/tick_boss.json
+++ b/content/bosses/tick_boss.json
@@ -1,0 +1,8 @@
+{
+  "id": "tick_boss",
+  "name": "Bloodsucking Tick",
+  "hp": 500,
+  "immunities": ["physical"],
+  "requiredItems": ["match"],
+  "rewards": { "unlock": ["zone:kitchen"], "currency": { "pennies": 50 } }
+}

--- a/content/enemies/fly.json
+++ b/content/enemies/fly.json
@@ -1,0 +1,10 @@
+{
+  "id": "fly",
+  "name": "Fly",
+  "hp": 8,
+  "damagePerHit": 0,
+  "onHitPlayer": { "flat": 0, "dot": 0 },
+  "bounty": { "pennies": 1 },
+  "tags": ["swarm", "bug"],
+  "behaviors": { "enragedMultiplier": 2 }
+}

--- a/content/items/flyswatter.json
+++ b/content/items/flyswatter.json
@@ -1,0 +1,11 @@
+{
+  "id": "flyswatter",
+  "name": "Flyswatter",
+  "type": "weapon",
+  "damage": 8,
+  "cooldownMs": 100,
+  "durability": 200,
+  "consumable": false,
+  "requirements": [],
+  "effects": {}
+}

--- a/content/items/match.json
+++ b/content/items/match.json
@@ -1,0 +1,11 @@
+{
+  "id": "match",
+  "name": "Match",
+  "type": "consumable",
+  "damage": 250,
+  "cooldownMs": 0,
+  "durability": 1,
+  "consumable": true,
+  "requirements": [],
+  "effects": {}
+}

--- a/content/items/tape.json
+++ b/content/items/tape.json
@@ -1,0 +1,10 @@
+{
+  "id": "tape",
+  "name": "Tape",
+  "type": "consumable",
+  "damage": 0,
+  "cooldownMs": 0,
+  "consumable": true,
+  "requirements": [],
+  "effects": { "repair": { "itemId": "flyswatter", "amount": 100 } }
+}

--- a/content/store/zone1_store.json
+++ b/content/store/zone1_store.json
@@ -1,0 +1,11 @@
+{
+  "id": "zone1_store",
+  "items": [
+    { "itemId": "tape", "cost": { "pennies": 25 } },
+    {
+      "itemId": "match",
+      "cost": { "pennies": 50 },
+      "lockedUntil": "boss:tick_boss"
+    }
+  ]
+}

--- a/content/zones/picnic_table.json
+++ b/content/zones/picnic_table.json
@@ -1,0 +1,9 @@
+{
+  "id": "picnic_table",
+  "name": "The Picnic Table",
+  "enemies": ["fly"],
+  "actions": ["pester_parents", "attack_flies", "fight_tick"],
+  "store": "zone1_store",
+  "bosses": ["tick_boss"],
+  "rewards": { "unlock": ["zone:kitchen"] }
+}

--- a/notes.txt
+++ b/notes.txt
@@ -3,3 +3,4 @@
 - M0-03: Introduced Game engine with scene management, render helpers, and seeded RNG.
 - M0-04: Added global game state store and basic zone display.
 - M0-05: Implemented Zod validators for content schemas.
+- M0-06: Created initial content JSON and tuning; store prices in pennies.

--- a/tuning.json
+++ b/tuning.json
@@ -1,0 +1,17 @@
+{
+  "enraged": {
+    "fly": { "killsPerSecond": 6, "durationMs": 5000, "hpMultiplier": 2 }
+  },
+  "cooldowns": {
+    "attackFlies": { "base": 8000, "withFlyswatter": 100 }
+  },
+  "boss": {
+    "tick": { "hp": 500, "matchDamage": 250 }
+  },
+  "repair": {
+    "tape": { "flyswatter": 100 }
+  },
+  "pester": {
+    "pester_parents": { "threshold": 40 }
+  }
+}


### PR DESCRIPTION
## Summary
- add Picnic Table zone, basic items, and fly enemy JSON
- define zone1 store inventory and tick boss data
- introduce tuning values for enraged flies, cooldowns, and boss stats

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a678e90bf4832d8b0b74ee309405cc