### PR TITLE
feat(M0-07): add content loader with validation overlay

### DIFF
--- a/completions.txt
+++ b/completions.txt
@@ -4,7 +4,7 @@ M0-03 DONE 2025-08-21 01:25 - engine core with scene switching and RNG
 M0-04 DONE 2025-08-21 01:33 - global game state skeleton
 M0-05 DONE 2025-08-21 01:34 - Added Zod content schemas
 M0-06 DONE 2025-08-21 01:42 - Added initial content JSON and tuning
-M0-07 TODO 0000-00-00 00:00 -
+M0-07 DONE 2025-08-21 01:49 - Content loader validates JSON and shows overlay on failure
 M0-08 TODO 0000-00-00 00:00 -
 M0-09 TODO 0000-00-00 00:00 -
 M0-10 TODO 0000-00-00 00:00 -

--- a/notes.txt
+++ b/notes.txt
@@ -4,3 +4,4 @@
 - M0-04: Added global game state store and basic zone display.
 - M0-05: Implemented Zod validators for content schemas.
 - M0-06: Created initial content JSON and tuning; store prices in pennies.
+- M0-07: Added content loader with validation and error overlay.

--- a/src/content/load.ts
+++ b/src/content/load.ts
@@ -1,0 +1,117 @@
+import {
+  EnemySchema,
+  BossSchema,
+  ItemSchema,
+  ZoneSchema,
+  StoreSchema,
+  type Enemy,
+  type Boss,
+  type Item,
+  type Zone,
+  type Store,
+} from './schema';
+
+export interface GameContent {
+  enemies: Record<string, Enemy>;
+  bosses: Record<string, Boss>;
+  items: Record<string, Item>;
+  zones: Record<string, Zone>;
+  stores: Record<string, Store>;
+}
+
+export async function loadContent(): Promise<GameContent> {
+  const errors: string[] = [];
+
+  const enemies: Record<string, Enemy> = {};
+  const enemyModules = import.meta.glob('../../content/enemies/*.json', {
+    eager: true,
+    import: 'default',
+  });
+  for (const path in enemyModules) {
+    const data = enemyModules[path] as unknown;
+    const result = EnemySchema.safeParse(data);
+    if (result.success) {
+      enemies[result.data.id] = result.data;
+    } else {
+      const message = path + ': ' + result.error.message;
+      errors.push(message);
+    }
+  }
+
+  const bosses: Record<string, Boss> = {};
+  const bossModules = import.meta.glob('../../content/bosses/*.json', {
+    eager: true,
+    import: 'default',
+  });
+  for (const path in bossModules) {
+    const data = bossModules[path] as unknown;
+    const result = BossSchema.safeParse(data);
+    if (result.success) {
+      bosses[result.data.id] = result.data;
+    } else {
+      const message = path + ': ' + result.error.message;
+      errors.push(message);
+    }
+  }
+
+  const items: Record<string, Item> = {};
+  const itemModules = import.meta.glob('../../content/items/*.json', {
+    eager: true,
+    import: 'default',
+  });
+  for (const path in itemModules) {
+    const data = itemModules[path] as unknown;
+    const result = ItemSchema.safeParse(data);
+    if (result.success) {
+      items[result.data.id] = result.data;
+    } else {
+      const message = path + ': ' + result.error.message;
+      errors.push(message);
+    }
+  }
+
+  const zones: Record<string, Zone> = {};
+  const zoneModules = import.meta.glob('../../content/zones/*.json', {
+    eager: true,
+    import: 'default',
+  });
+  for (const path in zoneModules) {
+    const data = zoneModules[path] as unknown;
+    const result = ZoneSchema.safeParse(data);
+    if (result.success) {
+      zones[result.data.id] = result.data;
+    } else {
+      const message = path + ': ' + result.error.message;
+      errors.push(message);
+    }
+  }
+
+  const stores: Record<string, Store> = {};
+  const storeModules = import.meta.glob('../../content/store/*.json', {
+    eager: true,
+    import: 'default',
+  });
+  for (const path in storeModules) {
+    const data = storeModules[path] as unknown;
+    const result = StoreSchema.safeParse(data);
+    if (result.success) {
+      stores[result.data.id] = result.data;
+    } else {
+      const message = path + ': ' + result.error.message;
+      errors.push(message);
+    }
+  }
+
+  if (errors.length > 0) {
+    const combined = errors.join('\n');
+    throw new Error(combined);
+  }
+
+  return {
+    enemies,
+    bosses,
+    items,
+    zones,
+    stores,
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,8 @@ import { Game, Scene } from './engine/game';
 import type { Rng } from './engine/rng';
 import { drawText } from './engine/render';
 import { gameState } from './state/gameState';
+import { loadContent } from './content/load';
+import { showOverlay } from './ui/overlay';
 
 class DemoScene implements Scene {
   private x: number;
@@ -27,7 +29,20 @@ class DemoScene implements Scene {
   }
 }
 
-function start(): void {
+async function start(): Promise<void> {
+  try {
+    await loadContent();
+  } catch (e) {
+    let message: string;
+    if (e instanceof Error) {
+      message = e.message;
+    } else {
+      message = String(e);
+    }
+    showOverlay(message);
+    return;
+  }
+
   const element = document.getElementById('game');
   if (element === null) {
     throw new Error('Canvas element not found');

--- a/src/ui/overlay.ts
+++ b/src/ui/overlay.ts
@@ -1,0 +1,15 @@
+export function showOverlay(message: string): void {
+  const overlay = document.createElement('div');
+  overlay.style.position = 'fixed';
+  overlay.style.top = '0';
+  overlay.style.left = '0';
+  overlay.style.width = '100%';
+  overlay.style.height = '100%';
+  overlay.style.backgroundColor = 'rgba(0, 0, 0, 0.8)';
+  overlay.style.color = 'white';
+  overlay.style.fontFamily = 'monospace';
+  overlay.style.whiteSpace = 'pre-wrap';
+  overlay.style.padding = '20px';
+  overlay.textContent = message;
+  document.body.appendChild(overlay);
+}


### PR DESCRIPTION
## Summary
- load all game content JSON and validate using Zod
- display full-screen overlay with error details when validation fails
- hook validation into startup sequence

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a67aa8dd94832d92e87179ebb176b9