### PR TITLE
feat(M0-08): add basic combat system

### DIFF
--- a/completions.txt
+++ b/completions.txt
@@ -5,7 +5,7 @@ M0-04 DONE 2025-08-21 01:33 - global game state skeleton
 M0-05 DONE 2025-08-21 01:34 - Added Zod content schemas
 M0-06 DONE 2025-08-21 01:42 - Added initial content JSON and tuning
 M0-07 DONE 2025-08-21 01:49 - Content loader validates JSON and shows overlay on failure
-M0-08 TODO 0000-00-00 00:00 -
+M0-08 DONE 2025-08-21 01:53 - Basic combat system with kill feed
 M0-09 TODO 0000-00-00 00:00 -
 M0-10 TODO 0000-00-00 00:00 -
 M0-11 TODO 0000-00-00 00:00 -

--- a/notes.txt
+++ b/notes.txt
@@ -5,3 +5,4 @@
 - M0-05: Implemented Zod validators for content schemas.
 - M0-06: Created initial content JSON and tuning; store prices in pennies.
 - M0-07: Added content loader with validation and error overlay.
+- M0-08: Added combat system with attacks, bounty rewards, and kill feed demo.

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,8 +2,14 @@ import { Game, Scene } from './engine/game';
 import type { Rng } from './engine/rng';
 import { drawText } from './engine/render';
 import { gameState } from './state/gameState';
-import { loadContent } from './content/load';
+import { loadContent, type GameContent } from './content/load';
 import { showOverlay } from './ui/overlay';
+import {
+  spawnEnemy,
+  attackSingle,
+  attackGroup,
+  getKillFeed,
+} from './systems/combat';
 
 class DemoScene implements Scene {
   private x: number;
@@ -26,12 +32,20 @@ class DemoScene implements Scene {
     drawText(context, 'Demo', 20, 60);
     const zoneText = 'Zone: ' + gameState.currentZone;
     drawText(context, zoneText, 20, 80);
+    const penniesText = 'Pennies: ' + gameState.player.pennies;
+    drawText(context, penniesText, 20, 100);
+    const feed = getKillFeed();
+    for (let i = 0; i < feed.length; i = i + 1) {
+      const lineY = 120 + i * 20;
+      drawText(context, feed[i], 20, lineY);
+    }
   }
 }
 
 async function start(): Promise<void> {
+  let content: GameContent;
   try {
-    await loadContent();
+    content = await loadContent();
   } catch (e) {
     let message: string;
     if (e instanceof Error) {
@@ -42,6 +56,12 @@ async function start(): Promise<void> {
     showOverlay(message);
     return;
   }
+
+  spawnEnemy('fly', content);
+  attackSingle('fly', 8, content);
+  spawnEnemy('fly', content);
+  spawnEnemy('fly', content);
+  attackGroup('fly', 8, content);
 
   const element = document.getElementById('game');
   if (element === null) {

--- a/src/systems/combat.ts
+++ b/src/systems/combat.ts
@@ -1,0 +1,72 @@
+import type { GameContent } from '../content/load';
+import type { Enemy } from '../content/schema';
+import { gameState } from '../state/gameState';
+
+interface EnemyInstance {
+  id: string;
+  hp: number;
+}
+
+const activeEnemies: EnemyInstance[] = [];
+const killFeed: string[] = [];
+
+export function spawnEnemy(enemyId: string, content: GameContent): void {
+  const template = content.enemies[enemyId];
+  if (template === undefined) {
+    throw new Error('Unknown enemy: ' + enemyId);
+  }
+  const instance: EnemyInstance = { id: enemyId, hp: template.hp };
+  activeEnemies.push(instance);
+}
+
+function rewardKill(enemy: Enemy): void {
+  const pennies = enemy.bounty.pennies;
+  if (pennies !== undefined) {
+    gameState.player.pennies = gameState.player.pennies + pennies;
+  }
+  killFeed.push('Defeated ' + enemy.name);
+  if (enemy.id === 'fly') {
+    gameState.flags.flyKills = gameState.flags.flyKills + 1;
+  }
+}
+
+export function attackSingle(
+  enemyId: string,
+  damage: number,
+  content: GameContent
+): void {
+  for (let i = 0; i < activeEnemies.length; i = i + 1) {
+    const instance = activeEnemies[i];
+    if (instance.id === enemyId) {
+      instance.hp = instance.hp - damage;
+      if (instance.hp <= 0) {
+        activeEnemies.splice(i, 1);
+        const enemy = content.enemies[enemyId];
+        rewardKill(enemy);
+      }
+      return;
+    }
+  }
+}
+
+export function attackGroup(
+  enemyId: string,
+  damage: number,
+  content: GameContent
+): void {
+  for (let i = activeEnemies.length - 1; i >= 0; i = i - 1) {
+    const instance = activeEnemies[i];
+    if (instance.id === enemyId) {
+      instance.hp = instance.hp - damage;
+      if (instance.hp <= 0) {
+        activeEnemies.splice(i, 1);
+        const enemy = content.enemies[enemyId];
+        rewardKill(enemy);
+      }
+    }
+  }
+}
+
+export function getKillFeed(): readonly string[] {
+  return killFeed;
+}


### PR DESCRIPTION
## Summary
- add combat module with single and group attack helpers and kill feed
- integrate combat demo into main scene, showing rewards and feed
- log progress for M0-08

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a67b70bc1c832d8ef5bf797d04c0d7