### PR TITLE
feat(M0-09): add pester system

### DIFF
--- a/completions.txt
+++ b/completions.txt
@@ -6,7 +6,7 @@ M0-05 DONE 2025-08-21 01:34 - Added Zod content schemas
 M0-06 DONE 2025-08-21 01:42 - Added initial content JSON and tuning
 M0-07 DONE 2025-08-21 01:49 - Content loader validates JSON and shows overlay on failure
 M0-08 DONE 2025-08-21 01:53 - Basic combat system with kill feed
-M0-09 TODO 0000-00-00 00:00 -
+M0-09 DONE 2025-08-21 02:01 - Added weighted pester system
 M0-10 TODO 0000-00-00 00:00 -
 M0-11 TODO 0000-00-00 00:00 -
 M0-12 TODO 0000-00-00 00:00 -

--- a/notes.txt
+++ b/notes.txt
@@ -6,3 +6,4 @@
 - M0-06: Created initial content JSON and tuning; store prices in pennies.
 - M0-07: Added content loader with validation and error overlay.
 - M0-08: Added combat system with attacks, bounty rewards, and kill feed demo.
+- M0-09: Added pester system with weighted increments and unlock reward.

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import {
   attackGroup,
   getKillFeed,
 } from './systems/combat';
+import { pester } from './systems/pester';
 
 class DemoScene implements Scene {
   private x: number;
@@ -24,6 +25,7 @@ class DemoScene implements Scene {
     if (this.x > 100) {
       this.x = 20;
     }
+    pester('pester_parents', rng);
   }
 
   draw(context: CanvasRenderingContext2D): void {
@@ -34,9 +36,15 @@ class DemoScene implements Scene {
     drawText(context, zoneText, 20, 80);
     const penniesText = 'Pennies: ' + gameState.player.pennies;
     drawText(context, penniesText, 20, 100);
+    const pesterEntry = gameState.pester['pester_parents'];
+    const pesterText = 'Pester: ' + pesterEntry.value;
+    drawText(context, pesterText, 20, 120);
+    if (pesterEntry.unlocked) {
+      drawText(context, 'Pester Unlocked', 20, 140);
+    }
     const feed = getKillFeed();
     for (let i = 0; i < feed.length; i = i + 1) {
-      const lineY = 120 + i * 20;
+      const lineY = 160 + i * 20;
       drawText(context, feed[i], 20, lineY);
     }
   }

--- a/src/state/gameState.ts
+++ b/src/state/gameState.ts
@@ -11,4 +11,7 @@ export const gameState: GameState = {
     flyKills: 0,
     zoneUnlocks: ['picnic_table'],
   },
+  pester: {
+    pester_parents: { value: 0, unlocked: false },
+  },
 };

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -15,8 +15,14 @@ export interface GameFlags {
   zoneUnlocks: string[];
 }
 
+export interface PesterEntry {
+  value: number;
+  unlocked: boolean;
+}
+
 export interface GameState {
   player: PlayerState;
   currentZone: string;
   flags: GameFlags;
+  pester: Record<string, PesterEntry>;
 }

--- a/src/systems/pester.ts
+++ b/src/systems/pester.ts
@@ -1,0 +1,75 @@
+import { gameState } from '../state/gameState';
+import type { Rng } from '../engine/rng';
+import tuning from '../../tuning.json';
+
+interface PesterConfig {
+  threshold: number;
+  increments: { '1': number; '2': number; '3': number; '0'?: number };
+  reward?: { grantItem?: string };
+}
+
+const configs: Record<string, PesterConfig> = {
+  pester_parents: {
+    threshold: tuning.pester.pester_parents.threshold,
+    increments: { '1': 0.5, '2': 0.25, '3': 0.125, '0': 0.125 },
+    reward: { grantItem: 'flyswatter' },
+  },
+};
+
+function grantItem(id: string): void {
+  const inventory = gameState.player.inventory;
+  for (let i = 0; i < inventory.length; i = i + 1) {
+    const item = inventory[i];
+    if (item.id === id) {
+      item.quantity = item.quantity + 1;
+      return;
+    }
+  }
+  inventory.push({ id, quantity: 1 });
+}
+
+function chooseIncrement(
+  weights: { '1': number; '2': number; '3': number; '0'?: number },
+  rng: Rng
+): number {
+  const roll = rng.next();
+  let cumulative = 0;
+  cumulative = cumulative + weights['1'];
+  if (roll < cumulative) {
+    return 1;
+  }
+  cumulative = cumulative + weights['2'];
+  if (roll < cumulative) {
+    return 2;
+  }
+  cumulative = cumulative + weights['3'];
+  if (roll < cumulative) {
+    return 3;
+  }
+  return 0;
+}
+
+export function pester(id: string, rng: Rng): boolean {
+  const config = configs[id];
+  if (config === undefined) {
+    return false;
+  }
+  let entry = gameState.pester[id];
+  if (entry === undefined) {
+    entry = { value: 0, unlocked: false };
+    gameState.pester[id] = entry;
+  }
+  if (entry.unlocked) {
+    return true;
+  }
+  const amount = chooseIncrement(config.increments, rng);
+  entry.value = entry.value + amount;
+  if (entry.value >= config.threshold) {
+    entry.unlocked = true;
+    const rewardItem = config.reward?.grantItem;
+    if (rewardItem !== undefined) {
+      grantItem(rewardItem);
+    }
+  }
+  return entry.unlocked;
+}


### PR DESCRIPTION
## Summary
- implement weighted pester system with unlock rewards
- track pester progress in game state and demo
- document task completion and notes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a67d3de2e0832d9284b599f48efc8c