### PR TITLE
feat(M0-10): add economy system

### DIFF
--- a/completions.txt
+++ b/completions.txt
@@ -7,7 +7,7 @@ M0-06 DONE 2025-08-21 01:42 - Added initial content JSON and tuning
 M0-07 DONE 2025-08-21 01:49 - Content loader validates JSON and shows overlay on failure
 M0-08 DONE 2025-08-21 01:53 - Basic combat system with kill feed
 M0-09 DONE 2025-08-21 02:01 - Added weighted pester system
-M0-10 TODO 0000-00-00 00:00 -
+M0-10 DONE 2025-08-21 02:08 - Added economy system
 M0-11 TODO 0000-00-00 00:00 -
 M0-12 TODO 0000-00-00 00:00 -
 M0-13 TODO 0000-00-00 00:00 -

--- a/notes.txt
+++ b/notes.txt
@@ -7,3 +7,4 @@
 - M0-07: Added content loader with validation and error overlay.
 - M0-08: Added combat system with attacks, bounty rewards, and kill feed demo.
 - M0-09: Added pester system with weighted increments and unlock reward.
+- M0-10: Added economy system with purchases and durability repair. Store locks ignored.

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import {
   getKillFeed,
 } from './systems/combat';
 import { pester } from './systems/pester';
+import { addPennies, purchaseItem, useItem } from './systems/economy';
 
 class DemoScene implements Scene {
   private x: number;
@@ -43,9 +44,21 @@ class DemoScene implements Scene {
       drawText(context, 'Pester Unlocked', 20, 140);
     }
     const feed = getKillFeed();
+    let lineY = 160;
     for (let i = 0; i < feed.length; i = i + 1) {
-      const lineY = 160 + i * 20;
       drawText(context, feed[i], 20, lineY);
+      lineY = lineY + 20;
+    }
+    const inventory = gameState.player.inventory;
+    for (let i = 0; i < inventory.length; i = i + 1) {
+      const item = inventory[i];
+      const itemText = item.id + ' x' + item.quantity;
+      drawText(context, itemText, 20, lineY);
+      if (item.durability !== undefined) {
+        const durText = 'Durability: ' + item.durability;
+        drawText(context, durText, 160, lineY);
+      }
+      lineY = lineY + 20;
     }
   }
 }
@@ -70,6 +83,15 @@ async function start(): Promise<void> {
   spawnEnemy('fly', content);
   spawnEnemy('fly', content);
   attackGroup('fly', 8, content);
+
+  gameState.player.inventory.push({
+    id: 'flyswatter',
+    quantity: 1,
+    durability: 50,
+  });
+  addPennies(100);
+  purchaseItem('zone1_store', 'tape', content);
+  useItem('tape', content);
 
   const element = document.getElementById('game');
   if (element === null) {

--- a/src/systems/economy.ts
+++ b/src/systems/economy.ts
@@ -1,0 +1,129 @@
+import type { GameContent } from '../content/load';
+import { gameState } from '../state/gameState';
+import type { Store } from '../content/schema';
+import type { ItemInstance } from '../state/types';
+
+export function addPennies(amount: number): void {
+  gameState.player.pennies = gameState.player.pennies + amount;
+}
+
+function findStoreItem(
+  store: Store,
+  itemId: string
+): { cost: number } | undefined {
+  for (let i = 0; i < store.items.length; i = i + 1) {
+    const entry = store.items[i];
+    if (entry.itemId === itemId) {
+      let cost = 0;
+      const pennies = entry.cost.pennies;
+      if (pennies !== undefined) {
+        cost = pennies;
+      }
+      return { cost };
+    }
+  }
+  return undefined;
+}
+
+function addToInventory(itemId: string, content: GameContent): void {
+  const template = content.items[itemId];
+  if (template === undefined) {
+    throw new Error('Unknown item: ' + itemId);
+  }
+  const inventory = gameState.player.inventory;
+  for (let i = 0; i < inventory.length; i = i + 1) {
+    const entry = inventory[i];
+    if (entry.id === itemId) {
+      entry.quantity = entry.quantity + 1;
+      return;
+    }
+  }
+  const newEntry: ItemInstance = { id: itemId, quantity: 1 };
+  if (template.durability !== undefined) {
+    newEntry.durability = template.durability;
+  }
+  inventory.push(newEntry);
+}
+
+export function purchaseItem(
+  storeId: string,
+  itemId: string,
+  content: GameContent
+): boolean {
+  const store = content.stores[storeId];
+  if (store === undefined) {
+    return false;
+  }
+  const info = findStoreItem(store, itemId);
+  if (info === undefined) {
+    return false;
+  }
+  if (gameState.player.pennies < info.cost) {
+    return false;
+  }
+  gameState.player.pennies = gameState.player.pennies - info.cost;
+  addToInventory(itemId, content);
+  return true;
+}
+
+function repairItem(
+  targetItemId: string,
+  amount: number,
+  content: GameContent
+): void {
+  const inventory = gameState.player.inventory;
+  for (let i = 0; i < inventory.length; i = i + 1) {
+    const entry = inventory[i];
+    if (entry.id === targetItemId) {
+      const template = content.items[targetItemId];
+      if (template === undefined) {
+        return;
+      }
+      let current = entry.durability;
+      if (current === undefined) {
+        current = 0;
+      }
+      let max = template.durability;
+      if (max === undefined) {
+        max = current + amount;
+      }
+      let next = current + amount;
+      if (next > max) {
+        next = max;
+      }
+      entry.durability = next;
+      return;
+    }
+  }
+}
+
+interface RepairEffect {
+  itemId: string;
+  amount: number;
+}
+
+export function useItem(itemId: string, content: GameContent): boolean {
+  const inventory = gameState.player.inventory;
+  for (let i = 0; i < inventory.length; i = i + 1) {
+    const entry = inventory[i];
+    if (entry.id === itemId) {
+      const template = content.items[itemId];
+      if (template === undefined) {
+        return false;
+      }
+      const effects = template.effects as { repair?: RepairEffect } | undefined;
+      if (effects !== undefined) {
+        const repair = effects.repair;
+        if (repair !== undefined) {
+          repairItem(repair.itemId, repair.amount, content);
+        }
+      }
+      entry.quantity = entry.quantity - 1;
+      if (entry.quantity <= 0) {
+        inventory.splice(i, 1);
+      }
+      return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary
- implement economy system for currency, store purchases, and durability repair
- display inventory and durability in demo scene and exercise purchases
- note M0-10 completion

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a67f1fbd94832da15c22a32887fcbc