### PR TITLE
feat(M0-11): add progression system

### DIFF
--- a/completions.txt
+++ b/completions.txt
@@ -8,7 +8,7 @@ M0-07 DONE 2025-08-21 01:49 - Content loader validates JSON and shows overlay on
 M0-08 DONE 2025-08-21 01:53 - Basic combat system with kill feed
 M0-09 DONE 2025-08-21 02:01 - Added weighted pester system
 M0-10 DONE 2025-08-21 02:08 - Added economy system
-M0-11 TODO 0000-00-00 00:00 -
+M0-11 DONE 2025-08-21 02:16 - Progression system unlocks boss and Kitchen zone
 M0-12 TODO 0000-00-00 00:00 -
 M0-13 TODO 0000-00-00 00:00 -
 M0-14 TODO 0000-00-00 00:00 -

--- a/content/zones/kitchen.json
+++ b/content/zones/kitchen.json
@@ -1,0 +1,9 @@
+{
+  "id": "kitchen",
+  "name": "The Kitchen",
+  "enemies": [],
+  "actions": [],
+  "store": "zone1_store",
+  "bosses": [],
+  "rewards": { "unlock": [] }
+}

--- a/notes.txt
+++ b/notes.txt
@@ -8,3 +8,4 @@
 - M0-08: Added combat system with attacks, bounty rewards, and kill feed demo.
 - M0-09: Added pester system with weighted increments and unlock reward.
 - M0-10: Added economy system with purchases and durability repair. Store locks ignored.
+- M0-11: Added progression system; boss unlocks at 100 fly kills and Kitchen zone opens after victory.

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import {
 } from './systems/combat';
 import { pester } from './systems/pester';
 import { addPennies, purchaseItem, useItem } from './systems/economy';
+import { markBossDefeated } from './systems/progression';
 
 class DemoScene implements Scene {
   private x: number;
@@ -92,6 +93,7 @@ async function start(): Promise<void> {
   addPennies(100);
   purchaseItem('zone1_store', 'tape', content);
   useItem('tape', content);
+  markBossDefeated('tick_boss', content);
 
   const element = document.getElementById('game');
   if (element === null) {

--- a/src/state/gameState.ts
+++ b/src/state/gameState.ts
@@ -10,6 +10,8 @@ export const gameState: GameState = {
   flags: {
     flyKills: 0,
     zoneUnlocks: ['picnic_table'],
+    bossUnlocked: [],
+    bossDefeated: [],
   },
   pester: {
     pester_parents: { value: 0, unlocked: false },

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -13,6 +13,8 @@ export interface PlayerState {
 export interface GameFlags {
   flyKills: number;
   zoneUnlocks: string[];
+  bossUnlocked: string[];
+  bossDefeated: string[];
 }
 
 export interface PesterEntry {

--- a/src/systems/combat.ts
+++ b/src/systems/combat.ts
@@ -1,6 +1,7 @@
 import type { GameContent } from '../content/load';
 import type { Enemy } from '../content/schema';
 import { gameState } from '../state/gameState';
+import { checkBossUnlock } from './progression';
 
 interface EnemyInstance {
   id: string;
@@ -27,6 +28,7 @@ function rewardKill(enemy: Enemy): void {
   killFeed.push('Defeated ' + enemy.name);
   if (enemy.id === 'fly') {
     gameState.flags.flyKills = gameState.flags.flyKills + 1;
+    checkBossUnlock();
   }
 }
 

--- a/src/systems/progression.ts
+++ b/src/systems/progression.ts
@@ -1,0 +1,54 @@
+import { gameState } from '../state/gameState';
+import type { GameContent } from '../content/load';
+
+interface BossRewards {
+  unlock?: string[];
+}
+
+interface BossData {
+  rewards?: BossRewards;
+}
+
+export function checkBossUnlock(): void {
+  const flags = gameState.flags;
+  if (flags.flyKills >= 100) {
+    const index = flags.bossUnlocked.indexOf('tick_boss');
+    if (index === -1) {
+      flags.bossUnlocked.push('tick_boss');
+    }
+  }
+}
+
+export function markBossDefeated(bossId: string, content: GameContent): void {
+  const defeated = gameState.flags.bossDefeated;
+  if (defeated.indexOf(bossId) === -1) {
+    defeated.push(bossId);
+  }
+  const unlocked = gameState.flags.bossUnlocked;
+  const unlockIndex = unlocked.indexOf(bossId);
+  if (unlockIndex !== -1) {
+    unlocked.splice(unlockIndex, 1);
+  }
+  const boss = content.bosses[bossId] as BossData | undefined;
+  if (boss === undefined) {
+    return;
+  }
+  const rewards = boss.rewards;
+  if (rewards === undefined) {
+    return;
+  }
+  const unlocks = rewards.unlock;
+  if (unlocks === undefined) {
+    return;
+  }
+  for (let i = 0; i < unlocks.length; i = i + 1) {
+    const token = unlocks[i];
+    if (token.startsWith('zone:')) {
+      const zoneId = token.slice(5);
+      const zones = gameState.flags.zoneUnlocks;
+      if (zones.indexOf(zoneId) === -1) {
+        zones.push(zoneId);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- track boss unlocks and defeats in game state
- unlock Tick boss after 100 fly kills and open Kitchen zone when defeated
- wire combat kills into progression checks and add placeholder Kitchen zone content

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a680c15150832db3eb7c693d853091