### PR TITLE
feat(M0-12): add cooldown manager

### DIFF
--- a/completions.txt
+++ b/completions.txt
@@ -9,7 +9,7 @@ M0-08 DONE 2025-08-21 01:53 - Basic combat system with kill feed
 M0-09 DONE 2025-08-21 02:01 - Added weighted pester system
 M0-10 DONE 2025-08-21 02:08 - Added economy system
 M0-11 DONE 2025-08-21 02:16 - Progression system unlocks boss and Kitchen zone
-M0-12 TODO 0000-00-00 00:00 -
+M0-12 DONE 2025-08-21 02:22 - Added cooldown manager
 M0-13 TODO 0000-00-00 00:00 -
 M0-14 TODO 0000-00-00 00:00 -
 M0-15 TODO 0000-00-00 00:00 -

--- a/notes.txt
+++ b/notes.txt
@@ -9,3 +9,4 @@
 - M0-09: Added pester system with weighted increments and unlock reward.
 - M0-10: Added economy system with purchases and durability repair. Store locks ignored.
 - M0-11: Added progression system; boss unlocks at 100 fly kills and Kitchen zone opens after victory.
+- M0-12: Added cooldown manager and demo pester cooldown.

--- a/src/engine/game.ts
+++ b/src/engine/game.ts
@@ -1,5 +1,6 @@
 import { Rng } from './rng';
 import { clear } from './render';
+import { updateCooldowns } from '../systems/cooldown';
 
 export interface Scene {
   update(delta: number, rng: Rng): void;
@@ -31,6 +32,7 @@ export class Game {
   private loop(timestamp: number): void {
     const delta = (timestamp - this.previous) / 1000;
     this.previous = timestamp;
+    updateCooldowns(delta * 1000);
     this.current.update(delta, this.rng);
     clear(this.context);
     this.current.draw(this.context);

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import {
   getKillFeed,
 } from './systems/combat';
 import { pester } from './systems/pester';
+import { startCooldown, isOnCooldown } from './systems/cooldown';
 import { addPennies, purchaseItem, useItem } from './systems/economy';
 import { markBossDefeated } from './systems/progression';
 
@@ -27,7 +28,11 @@ class DemoScene implements Scene {
     if (this.x > 100) {
       this.x = 20;
     }
-    pester('pester_parents', rng);
+    const onCooldown = isOnCooldown('pester_parents');
+    if (!onCooldown) {
+      pester('pester_parents', rng);
+      startCooldown('pester_parents', 1000);
+    }
   }
 
   draw(context: CanvasRenderingContext2D): void {

--- a/src/state/gameState.ts
+++ b/src/state/gameState.ts
@@ -16,4 +16,5 @@ export const gameState: GameState = {
   pester: {
     pester_parents: { value: 0, unlocked: false },
   },
+  cooldowns: {},
 };

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -27,4 +27,5 @@ export interface GameState {
   currentZone: string;
   flags: GameFlags;
   pester: Record<string, PesterEntry>;
+  cooldowns: Record<string, number>;
 }

--- a/src/systems/cooldown.ts
+++ b/src/systems/cooldown.ts
@@ -1,0 +1,41 @@
+import { gameState } from '../state/gameState';
+
+export function startCooldown(id: string, durationMs: number): void {
+  gameState.cooldowns[id] = durationMs;
+}
+
+export function updateCooldowns(deltaMs: number): void {
+  const entries = Object.keys(gameState.cooldowns);
+  for (let i = 0; i < entries.length; i = i + 1) {
+    const key = entries[i];
+    let remaining = gameState.cooldowns[key];
+    remaining = remaining - deltaMs;
+    if (remaining <= 0) {
+      delete gameState.cooldowns[key];
+    } else {
+      gameState.cooldowns[key] = remaining;
+    }
+  }
+}
+
+export function isOnCooldown(id: string): boolean {
+  const remaining = gameState.cooldowns[id];
+  if (remaining === undefined) {
+    return false;
+  }
+  if (remaining > 0) {
+    return true;
+  }
+  return false;
+}
+
+export function getCooldownRatio(id: string, totalMs: number): number {
+  const remaining = gameState.cooldowns[id];
+  if (remaining === undefined) {
+    return 0;
+  }
+  if (totalMs <= 0) {
+    return 0;
+  }
+  return remaining / totalMs;
+}


### PR DESCRIPTION
## Summary
- add cooldown system for per-action timers
- update game loop to tick cooldowns
- use cooldown in demo scene and log M0-12 completion

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6823f5c94832dae77c2a39617db7e