### PR TITLE
feat(M0-14): add HUD and debug overlay

### DIFF
--- a/completions.txt
+++ b/completions.txt
@@ -11,7 +11,7 @@ M0-10 DONE 2025-08-21 02:08 - Added economy system
 M0-11 DONE 2025-08-21 02:16 - Progression system unlocks boss and Kitchen zone
 M0-12 DONE 2025-08-21 02:22 - Added cooldown manager
 M0-13 DONE 2025-08-21 02:30 - Enraged flies require two hits
-M0-14 TODO 0000-00-00 00:00 -
+M0-14 DONE 2025-08-21 02:37 - HUD and debug overlay
 M0-15 TODO 0000-00-00 00:00 -
 M0-16 TODO 0000-00-00 00:00 -
 M0-17 TODO 0000-00-00 00:00 -

--- a/notes.txt
+++ b/notes.txt
@@ -11,3 +11,4 @@
 - M0-11: Added progression system; boss unlocks at 100 fly kills and Kitchen zone opens after victory.
 - M0-12: Added cooldown manager and demo pester cooldown.
 - M0-13: Enraged flies trigger after rapid kills; require two hits and expire after five seconds.
+- M0-14: HUD displays HP, pennies, zone; debug overlay shows FPS, flags, enraged timer.

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { drawText } from './engine/render';
 import { gameState } from './state/gameState';
 import { loadContent, type GameContent } from './content/load';
 import { showOverlay } from './ui/overlay';
+import { drawHud, drawDebug } from './ui/hud';
 import {
   spawnEnemy,
   attackSingle,
@@ -17,9 +18,11 @@ import { markBossDefeated } from './systems/progression';
 
 class DemoScene implements Scene {
   private x: number;
+  private fps: number;
 
   constructor() {
     this.x = 20;
+    this.fps = 0;
   }
 
   update(delta: number, rng: Rng): void {
@@ -33,22 +36,15 @@ class DemoScene implements Scene {
       pester('pester_parents', rng);
       startCooldown('pester_parents', 1000);
     }
+    if (delta > 0) {
+      this.fps = 1 / delta;
+    }
   }
 
   draw(context: CanvasRenderingContext2D): void {
     context.fillStyle = 'white';
     context.fillRect(this.x, 20, 20, 20);
     drawText(context, 'Demo', 20, 60);
-    const zoneText = 'Zone: ' + gameState.currentZone;
-    drawText(context, zoneText, 20, 80);
-    const penniesText = 'Pennies: ' + gameState.player.pennies;
-    drawText(context, penniesText, 20, 100);
-    const pesterEntry = gameState.pester['pester_parents'];
-    const pesterText = 'Pester: ' + pesterEntry.value;
-    drawText(context, pesterText, 20, 120);
-    if (pesterEntry.unlocked) {
-      drawText(context, 'Pester Unlocked', 20, 140);
-    }
     const feed = getKillFeed();
     let lineY = 160;
     for (let i = 0; i < feed.length; i = i + 1) {
@@ -66,6 +62,8 @@ class DemoScene implements Scene {
       }
       lineY = lineY + 20;
     }
+    drawHud(context);
+    drawDebug(context, this.fps);
   }
 }
 

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1,0 +1,35 @@
+import { drawText } from '../engine/render';
+import { gameState } from '../state/gameState';
+
+export function drawHud(context: CanvasRenderingContext2D): void {
+  let line = 20;
+  const hpText = 'HP: ' + gameState.player.hp;
+  drawText(context, hpText, 20, line);
+  line = line + 20;
+  const pennyText = 'Pennies: ' + gameState.player.pennies;
+  drawText(context, pennyText, 20, line);
+  line = line + 20;
+  const zoneText = 'Zone: ' + gameState.currentZone;
+  drawText(context, zoneText, 20, line);
+}
+
+export function drawDebug(
+  context: CanvasRenderingContext2D,
+  fps: number
+): void {
+  let line = 80;
+  const fpsText = 'FPS: ' + fps.toFixed(1);
+  drawText(context, fpsText, 20, line);
+  line = line + 20;
+  const flagText = 'Flags: ' + JSON.stringify(gameState.flags);
+  drawText(context, flagText, 20, line);
+  line = line + 20;
+  const now = performance.now();
+  let enragedSeconds = 0;
+  if (gameState.flags.enragedUntil > now) {
+    const remaining = gameState.flags.enragedUntil - now;
+    enragedSeconds = remaining / 1000;
+  }
+  const enragedText = 'Enraged: ' + enragedSeconds.toFixed(1);
+  drawText(context, enragedText, 20, line);
+}


### PR DESCRIPTION
## Summary
- add HUD showing HP, pennies, and current zone
- include debug overlay with FPS, flags, and enraged timer
- record task completion and notes for M0-14

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a685db6924832da040da18f5c68369