### PR TITLE
feat(M0-15): add action bar buttons

### DIFF
--- a/completions.txt
+++ b/completions.txt
@@ -12,7 +12,7 @@ M0-11 DONE 2025-08-21 02:16 - Progression system unlocks boss and Kitchen zone
 M0-12 DONE 2025-08-21 02:22 - Added cooldown manager
 M0-13 DONE 2025-08-21 02:30 - Enraged flies require two hits
 M0-14 DONE 2025-08-21 02:37 - HUD and debug overlay
-M0-15 TODO 0000-00-00 00:00 -
+M0-15 DONE 2025-08-21 02:41 - Added action bar buttons with cooldowns
 M0-16 TODO 0000-00-00 00:00 -
 M0-17 TODO 0000-00-00 00:00 -
 M0-18 TODO 0000-00-00 00:00 -

--- a/notes.txt
+++ b/notes.txt
@@ -12,3 +12,4 @@
 - M0-12: Added cooldown manager and demo pester cooldown.
 - M0-13: Enraged flies trigger after rapid kills; require two hits and expire after five seconds.
 - M0-14: HUD displays HP, pennies, zone; debug overlay shows FPS, flags, enraged timer.
+- M0-15: Added action bar with Attack, Pester, and Tick buttons showing cooldowns.

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,16 +5,9 @@ import { gameState } from './state/gameState';
 import { loadContent, type GameContent } from './content/load';
 import { showOverlay } from './ui/overlay';
 import { drawHud, drawDebug } from './ui/hud';
-import {
-  spawnEnemy,
-  attackSingle,
-  attackGroup,
-  getKillFeed,
-} from './systems/combat';
-import { pester } from './systems/pester';
-import { startCooldown, isOnCooldown } from './systems/cooldown';
-import { addPennies, purchaseItem, useItem } from './systems/economy';
-import { markBossDefeated } from './systems/progression';
+import { setupActionBar } from './ui/actionBar';
+import { getKillFeed } from './systems/combat';
+import { addPennies } from './systems/economy';
 
 class DemoScene implements Scene {
   private x: number;
@@ -30,11 +23,6 @@ class DemoScene implements Scene {
     this.x = this.x + step * delta;
     if (this.x > 100) {
       this.x = 20;
-    }
-    const onCooldown = isOnCooldown('pester_parents');
-    if (!onCooldown) {
-      pester('pester_parents', rng);
-      startCooldown('pester_parents', 1000);
     }
     if (delta > 0) {
       this.fps = 1 / delta;
@@ -82,21 +70,12 @@ async function start(): Promise<void> {
     return;
   }
 
-  spawnEnemy('fly', content);
-  attackSingle('fly', 8, content);
-  spawnEnemy('fly', content);
-  spawnEnemy('fly', content);
-  attackGroup('fly', 8, content);
-
   gameState.player.inventory.push({
     id: 'flyswatter',
     quantity: 1,
     durability: 50,
   });
   addPennies(100);
-  purchaseItem('zone1_store', 'tape', content);
-  useItem('tape', content);
-  markBossDefeated('tick_boss', content);
 
   const element = document.getElementById('game');
   if (element === null) {
@@ -120,6 +99,7 @@ async function start(): Promise<void> {
 
   const scene = new DemoScene();
   const game = new Game(context, scene, 1);
+  setupActionBar(content, game);
   game.start();
 }
 

--- a/src/ui/actionBar.ts
+++ b/src/ui/actionBar.ts
@@ -1,0 +1,109 @@
+import { spawnEnemy, attackGroup, attackSingle } from '../systems/combat';
+import { pester } from '../systems/pester';
+import { startCooldown, isOnCooldown } from '../systems/cooldown';
+import { gameState } from '../state/gameState';
+import type { Game } from '../engine/game';
+import type { GameContent } from '../content/load';
+
+interface ButtonConfig {
+  id: string;
+  label: string;
+  total: number;
+  onClick: () => void;
+}
+
+export function setupActionBar(content: GameContent, game: Game): void {
+  const bar = document.createElement('div');
+  bar.style.position = 'fixed';
+  bar.style.bottom = '10px';
+  bar.style.left = '50%';
+  bar.style.transform = 'translateX(-50%)';
+  bar.style.display = 'flex';
+  bar.style.gap = '10px';
+
+  const buttons: ButtonConfig[] = [];
+
+  const attackButton: ButtonConfig = {
+    id: 'attack_flies',
+    label: 'Attack Flies',
+    total: 8000,
+    onClick: () => {
+      const hasSwatter = gameState.player.inventory.some((item) => {
+        if (item.id === 'flyswatter') {
+          return true;
+        }
+        return false;
+      });
+      let duration = 8000;
+      if (hasSwatter) {
+        duration = 100;
+      }
+      spawnEnemy('fly', content);
+      attackSingle('fly', 8, content);
+      startCooldown('attack_flies', duration);
+    },
+  };
+  buttons.push(attackButton);
+
+  const pesterButton: ButtonConfig = {
+    id: 'pester_parents',
+    label: 'Pester Parents',
+    total: 1000,
+    onClick: () => {
+      pester('pester_parents', game.rng);
+      startCooldown('pester_parents', 1000);
+    },
+  };
+  buttons.push(pesterButton);
+
+  const tickButton: ButtonConfig = {
+    id: 'fight_tick',
+    label: 'Fight Tick',
+    total: 1000,
+    onClick: () => {
+      spawnEnemy('tick_boss', content);
+      attackGroup('tick_boss', 250, content);
+      startCooldown('fight_tick', 1000);
+    },
+  };
+  buttons.push(tickButton);
+
+  const elements: { [key: string]: HTMLButtonElement } = {};
+
+  for (let i = 0; i < buttons.length; i = i + 1) {
+    const config = buttons[i];
+    const button = document.createElement('button');
+    button.textContent = config.label;
+    button.onclick = () => {
+      const active = isOnCooldown(config.id);
+      if (active) {
+        return;
+      }
+      config.onClick();
+    };
+    bar.appendChild(button);
+    elements[config.id] = button;
+  }
+
+  document.body.appendChild(bar);
+
+  function update(): void {
+    for (let i = 0; i < buttons.length; i = i + 1) {
+      const config = buttons[i];
+      const button = elements[config.id];
+      const remaining = gameState.cooldowns[config.id];
+      if (remaining === undefined) {
+        button.disabled = false;
+        button.textContent = config.label;
+      } else {
+        button.disabled = true;
+        const seconds = remaining / 1000;
+        const text = config.label + ' (' + seconds.toFixed(1) + 's)';
+        button.textContent = text;
+      }
+    }
+    requestAnimationFrame(update);
+  }
+
+  update();
+}


### PR DESCRIPTION
## Summary
- add DOM-based action bar with Attack, Pester, and Tick controls
- integrate action bar into main loop and remove auto-pester demo
- track M0-15 completion and notes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a686e04808832da2cbbc89a8da035f