### PR TITLE
feat(M0-16): add store and inventory panels

### DIFF
--- a/completions.txt
+++ b/completions.txt
@@ -13,7 +13,7 @@ M0-12 DONE 2025-08-21 02:22 - Added cooldown manager
 M0-13 DONE 2025-08-21 02:30 - Enraged flies require two hits
 M0-14 DONE 2025-08-21 02:37 - HUD and debug overlay
 M0-15 DONE 2025-08-21 02:41 - Added action bar buttons with cooldowns
-M0-16 TODO 0000-00-00 00:00 -
+M0-16 DONE 2025-08-21 02:55 - Store and inventory panels with purchase confirmation
 M0-17 TODO 0000-00-00 00:00 -
 M0-18 TODO 0000-00-00 00:00 -
 M0-19 TODO 0000-00-00 00:00 -

--- a/notes.txt
+++ b/notes.txt
@@ -13,3 +13,4 @@
 - M0-13: Enraged flies trigger after rapid kills; require two hits and expire after five seconds.
 - M0-14: HUD displays HP, pennies, zone; debug overlay shows FPS, flags, enraged timer.
 - M0-15: Added action bar with Attack, Pester, and Tick buttons showing cooldowns.
+- M0-16: Added store and inventory panels with purchase confirmation.

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,8 @@ import { loadContent, type GameContent } from './content/load';
 import { showOverlay } from './ui/overlay';
 import { drawHud, drawDebug } from './ui/hud';
 import { setupActionBar } from './ui/actionBar';
+import { setupStorePanel } from './ui/storePanel';
+import { setupInventoryPanel } from './ui/inventoryPanel';
 import { getKillFeed } from './systems/combat';
 import { addPennies } from './systems/economy';
 
@@ -39,17 +41,6 @@ class DemoScene implements Scene {
       drawText(context, feed[i], 20, lineY);
       lineY = lineY + 20;
     }
-    const inventory = gameState.player.inventory;
-    for (let i = 0; i < inventory.length; i = i + 1) {
-      const item = inventory[i];
-      const itemText = item.id + ' x' + item.quantity;
-      drawText(context, itemText, 20, lineY);
-      if (item.durability !== undefined) {
-        const durText = 'Durability: ' + item.durability;
-        drawText(context, durText, 160, lineY);
-      }
-      lineY = lineY + 20;
-    }
     drawHud(context);
     drawDebug(context, this.fps);
   }
@@ -76,6 +67,9 @@ async function start(): Promise<void> {
     durability: 50,
   });
   addPennies(100);
+
+  setupInventoryPanel(content);
+  setupStorePanel(content);
 
   const element = document.getElementById('game');
   if (element === null) {

--- a/src/ui/inventoryPanel.ts
+++ b/src/ui/inventoryPanel.ts
@@ -1,0 +1,46 @@
+import { gameState } from '../state/gameState';
+import type { GameContent } from '../content/load';
+
+let panel: HTMLDivElement | undefined;
+let contentRef: GameContent | undefined;
+
+export function setupInventoryPanel(content: GameContent): void {
+  contentRef = content;
+  panel = document.createElement('div');
+  panel.style.position = 'fixed';
+  panel.style.right = '10px';
+  panel.style.bottom = '10px';
+  panel.style.border = '1px solid white';
+  panel.style.padding = '10px';
+  panel.style.background = 'rgba(0, 0, 0, 0.5)';
+  document.body.appendChild(panel);
+  refreshInventoryPanel();
+}
+
+export function refreshInventoryPanel(): void {
+  if (panel === undefined) {
+    return;
+  }
+  panel.innerHTML = '';
+  const header = document.createElement('div');
+  header.textContent = 'Inventory';
+  panel.appendChild(header);
+  const inventory = gameState.player.inventory;
+  for (let i = 0; i < inventory.length; i = i + 1) {
+    const entry = inventory[i];
+    let name = entry.id;
+    if (contentRef !== undefined) {
+      const info = contentRef.items[entry.id];
+      if (info !== undefined) {
+        name = info.name;
+      }
+    }
+    let text = name + ' x' + entry.quantity;
+    if (entry.durability !== undefined) {
+      text = text + ' (' + entry.durability + ')';
+    }
+    const row = document.createElement('div');
+    row.textContent = text;
+    panel.appendChild(row);
+  }
+}

--- a/src/ui/storePanel.ts
+++ b/src/ui/storePanel.ts
@@ -1,0 +1,73 @@
+import type { GameContent } from '../content/load';
+import { purchaseItem } from '../systems/economy';
+import { gameState } from '../state/gameState';
+import { refreshInventoryPanel } from './inventoryPanel';
+
+interface StoreButton {
+  itemId: string;
+  cost: number;
+  element: HTMLButtonElement;
+}
+
+export function setupStorePanel(content: GameContent): void {
+  const store = content.stores['zone1_store'];
+  if (store === undefined) {
+    return;
+  }
+  const panel = document.createElement('div');
+  panel.style.position = 'fixed';
+  panel.style.left = '10px';
+  panel.style.top = '10px';
+  panel.style.border = '1px solid white';
+  panel.style.padding = '10px';
+  panel.style.background = 'rgba(0, 0, 0, 0.5)';
+  const header = document.createElement('div');
+  header.textContent = 'Store';
+  panel.appendChild(header);
+  const buttons: StoreButton[] = [];
+  for (let i = 0; i < store.items.length; i = i + 1) {
+    const entry = store.items[i];
+    const itemId = entry.itemId;
+    let cost = 0;
+    if (entry.cost !== undefined) {
+      if (entry.cost.pennies !== undefined) {
+        cost = entry.cost.pennies;
+      }
+    }
+    let name = itemId;
+    const info = content.items[itemId];
+    if (info !== undefined) {
+      name = info.name;
+    }
+    const button = document.createElement('button');
+    button.textContent = name + ' - ' + cost + 'c';
+    button.onclick = () => {
+      const message = 'Buy ' + name + ' for ' + cost + ' pennies?';
+      const confirmed = window.confirm(message);
+      if (!confirmed) {
+        return;
+      }
+      const success = purchaseItem('zone1_store', itemId, content);
+      if (!success) {
+        window.alert('Purchase failed');
+        return;
+      }
+      refreshInventoryPanel();
+    };
+    panel.appendChild(button);
+    buttons.push({ itemId, cost, element: button });
+  }
+  document.body.appendChild(panel);
+  function update(): void {
+    for (let i = 0; i < buttons.length; i = i + 1) {
+      const entry = buttons[i];
+      if (gameState.player.pennies < entry.cost) {
+        entry.element.disabled = true;
+      } else {
+        entry.element.disabled = false;
+      }
+    }
+    requestAnimationFrame(update);
+  }
+  update();
+}


### PR DESCRIPTION
## Summary
- add store panel for zone one items with purchase confirmation
- show current inventory in a fixed panel
- integrate panels into main startup

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a68a07e924832dadeb0f85332dae6e