### PR TITLE
feat(M0-17): add zone map UI

### DIFF
--- a/completions.txt
+++ b/completions.txt
@@ -14,7 +14,7 @@ M0-13 DONE 2025-08-21 02:30 - Enraged flies require two hits
 M0-14 DONE 2025-08-21 02:37 - HUD and debug overlay
 M0-15 DONE 2025-08-21 02:41 - Added action bar buttons with cooldowns
 M0-16 DONE 2025-08-21 02:55 - Store and inventory panels with purchase confirmation
-M0-17 TODO 0000-00-00 00:00 -
+M0-17 DONE 2025-08-21 03:01 - Added zone map for Picnic Table and Kitchen
 M0-18 TODO 0000-00-00 00:00 -
 M0-19 TODO 0000-00-00 00:00 -
 M0-20 TODO 0000-00-00 00:00 -

--- a/notes.txt
+++ b/notes.txt
@@ -14,3 +14,4 @@
 - M0-14: HUD displays HP, pennies, zone; debug overlay shows FPS, flags, enraged timer.
 - M0-15: Added action bar with Attack, Pester, and Tick buttons showing cooldowns.
 - M0-16: Added store and inventory panels with purchase confirmation.
+- M0-17: Added zone map with two nodes; Kitchen button stays disabled until unlocked.

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import { drawHud, drawDebug } from './ui/hud';
 import { setupActionBar } from './ui/actionBar';
 import { setupStorePanel } from './ui/storePanel';
 import { setupInventoryPanel } from './ui/inventoryPanel';
+import { setupZoneMap } from './ui/zoneMap';
 import { getKillFeed } from './systems/combat';
 import { addPennies } from './systems/economy';
 
@@ -70,6 +71,7 @@ async function start(): Promise<void> {
 
   setupInventoryPanel(content);
   setupStorePanel(content);
+  setupZoneMap(content);
 
   const element = document.getElementById('game');
   if (element === null) {

--- a/src/ui/zoneMap.ts
+++ b/src/ui/zoneMap.ts
@@ -1,0 +1,64 @@
+import type { GameContent } from '../content/load';
+import { gameState } from '../state/gameState';
+
+interface ZoneButton {
+  id: string;
+  element: HTMLButtonElement;
+}
+
+export function setupZoneMap(content: GameContent): void {
+  const container = document.createElement('div');
+  container.style.position = 'fixed';
+  container.style.right = '10px';
+  container.style.top = '10px';
+  container.style.border = '1px solid white';
+  container.style.padding = '10px';
+  container.style.background = 'rgba(0, 0, 0, 0.5)';
+  const header = document.createElement('div');
+  header.textContent = 'Zones';
+  container.appendChild(header);
+
+  const ids = ['picnic_table', 'kitchen'];
+  const buttons: ZoneButton[] = [];
+
+  for (let i = 0; i < ids.length; i = i + 1) {
+    const id = ids[i];
+    const info = content.zones[id];
+    const button = document.createElement('button');
+    let name = id;
+    if (info !== undefined) {
+      name = info.name;
+    }
+    button.textContent = name;
+    button.onclick = () => {
+      const unlocked = gameState.flags.zoneUnlocks.indexOf(id);
+      if (unlocked !== -1) {
+        gameState.currentZone = id;
+      }
+    };
+    container.appendChild(button);
+    buttons.push({ id, element: button });
+  }
+
+  document.body.appendChild(container);
+
+  function update(): void {
+    for (let i = 0; i < buttons.length; i = i + 1) {
+      const entry = buttons[i];
+      const unlocked = gameState.flags.zoneUnlocks.indexOf(entry.id);
+      if (unlocked === -1) {
+        entry.element.disabled = true;
+      } else {
+        entry.element.disabled = false;
+      }
+      if (gameState.currentZone === entry.id) {
+        entry.element.style.fontWeight = 'bold';
+      } else {
+        entry.element.style.fontWeight = 'normal';
+      }
+    }
+    requestAnimationFrame(update);
+  }
+
+  update();
+}


### PR DESCRIPTION
## Summary
- add simple zone map with buttons for Picnic Table and Kitchen
- wire zone map into main startup
- log task completion in repository notes

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a68b6b5358832dbd5a50165cc70fa0