### PR TITLE
feat(M0-18): add localStorage save system

### DIFF
--- a/completions.txt
+++ b/completions.txt
@@ -15,7 +15,7 @@ M0-14 DONE 2025-08-21 02:37 - HUD and debug overlay
 M0-15 DONE 2025-08-21 02:41 - Added action bar buttons with cooldowns
 M0-16 DONE 2025-08-21 02:55 - Store and inventory panels with purchase confirmation
 M0-17 DONE 2025-08-21 03:01 - Added zone map for Picnic Table and Kitchen
-M0-18 TODO 0000-00-00 00:00 -
+M0-18 DONE 2025-08-21 03:08 - Added localStorage save/load
 M0-19 TODO 0000-00-00 00:00 -
 M0-20 TODO 0000-00-00 00:00 -
 T-01 TODO 0000-00-00 00:00 -

--- a/notes.txt
+++ b/notes.txt
@@ -15,3 +15,4 @@
 - M0-15: Added action bar with Attack, Pester, and Tick buttons showing cooldowns.
 - M0-16: Added store and inventory panels with purchase confirmation.
 - M0-17: Added zone map with two nodes; Kitchen button stays disabled until unlocked.
+- M0-18: Added localStorage save/load system with versioned slots.

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import { setupInventoryPanel } from './ui/inventoryPanel';
 import { setupZoneMap } from './ui/zoneMap';
 import { getKillFeed } from './systems/combat';
 import { addPennies } from './systems/economy';
+import { loadGame, saveGame, autoSave } from './systems/save';
 
 class DemoScene implements Scene {
   private x: number;
@@ -62,12 +63,18 @@ async function start(): Promise<void> {
     return;
   }
 
-  gameState.player.inventory.push({
-    id: 'flyswatter',
-    quantity: 1,
-    durability: 50,
-  });
-  addPennies(100);
+  const loaded = loadGame(1);
+  if (loaded !== null) {
+    Object.assign(gameState, loaded);
+  } else {
+    gameState.player.inventory.push({
+      id: 'flyswatter',
+      quantity: 1,
+      durability: 50,
+    });
+    addPennies(100);
+    saveGame(1, gameState);
+  }
 
   setupInventoryPanel(content);
   setupStorePanel(content);
@@ -96,6 +103,7 @@ async function start(): Promise<void> {
   const scene = new DemoScene();
   const game = new Game(context, scene, 1);
   setupActionBar(content, game);
+  autoSave(1, 5000);
   game.start();
 }
 

--- a/src/systems/save.ts
+++ b/src/systems/save.ts
@@ -1,0 +1,48 @@
+import { gameState } from '../state/gameState';
+import type { GameState } from '../state/types';
+
+const SAVE_VERSION = 1;
+
+interface SaveSlot {
+  version: number;
+  state: GameState;
+}
+
+function saveKey(slot: number): string {
+  return 'save:slot:' + String(slot);
+}
+
+export function saveGame(slot: number, state: GameState): void {
+  const data: SaveSlot = { version: SAVE_VERSION, state: state };
+  const json = JSON.stringify(data);
+  localStorage.setItem(saveKey(slot), json);
+}
+
+function migrate(data: unknown): SaveSlot {
+  return data as SaveSlot;
+}
+
+export function loadGame(slot: number): GameState | null {
+  const key = saveKey(slot);
+  const raw = localStorage.getItem(key);
+  if (raw === null) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as SaveSlot;
+    if (parsed.version !== SAVE_VERSION) {
+      const migrated = migrate(parsed);
+      return migrated.state;
+    }
+    return parsed.state;
+  } catch {
+    return null;
+  }
+}
+
+export function autoSave(slot: number, intervalMs: number): void {
+  function tick(): void {
+    saveGame(slot, gameState);
+  }
+  setInterval(tick, intervalMs);
+}


### PR DESCRIPTION
## Summary
- add save module with versioned slots and auto-save
- load existing slot on boot and create initial save when missing
- track completion for M0-18

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a68d0ee150832d834e8de30cbd5e78