### PR TITLE
feat(M0-19): add Cloudflare Pages docs and 404 page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # defenderof
+
+## Development
+- `npm run dev` to start a local server.
+- `npm run lint` to check code style.
+- `npm run build` to produce the `dist` directory.
+
+## Deployment
+This project targets Cloudflare Pages. Set the build command to `npm run build` and the build output directory to `dist`. The `public/404.html` file provides a basic not-found page.

--- a/completions.txt
+++ b/completions.txt
@@ -16,15 +16,15 @@ M0-15 DONE 2025-08-21 02:41 - Added action bar buttons with cooldowns
 M0-16 DONE 2025-08-21 02:55 - Store and inventory panels with purchase confirmation
 M0-17 DONE 2025-08-21 03:01 - Added zone map for Picnic Table and Kitchen
 M0-18 DONE 2025-08-21 03:08 - Added localStorage save/load
-M0-19 TODO 0000-00-00 00:00 -
+M0-19 BLOCKED 2025-08-21 03:14 - Manual smoke tests require browser environment
 M0-20 TODO 0000-00-00 00:00 -
-T-01 TODO 0000-00-00 00:00 -
-T-02 TODO 0000-00-00 00:00 -
-T-03 TODO 0000-00-00 00:00 -
-T-04 TODO 0000-00-00 00:00 -
-T-05 TODO 0000-00-00 00:00 -
-T-06 TODO 0000-00-00 00:00 -
-T-07 TODO 0000-00-00 00:00 -
+T-01 BLOCKED 2025-08-21 03:14 - Requires browser
+T-02 BLOCKED 2025-08-21 03:14 - Requires browser
+T-03 BLOCKED 2025-08-21 03:14 - Requires browser
+T-04 BLOCKED 2025-08-21 03:14 - Requires browser
+T-05 BLOCKED 2025-08-21 03:14 - Requires browser
+T-06 BLOCKED 2025-08-21 03:14 - Requires browser
+T-07 BLOCKED 2025-08-21 03:14 - Requires browser
 M1-01 TODO 0000-00-00 00:00 -
 M1-02 TODO 0000-00-00 00:00 -
 M1-03 TODO 0000-00-00 00:00 -

--- a/notes.txt
+++ b/notes.txt
@@ -16,3 +16,4 @@
 - M0-16: Added store and inventory panels with purchase confirmation.
 - M0-17: Added zone map with two nodes; Kitchen button stays disabled until unlocked.
 - M0-18: Added localStorage save/load system with versioned slots.
+- M0-19: Manual smoke tests require a browser; cannot run in this environment. Added 404 page and Cloudflare Pages deployment notes.

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Not Found</title>
+  </head>
+  <body>
+    <h1>404 - Page Not Found</h1>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- document Cloudflare Pages deployment steps
- add basic 404 page for static hosting
- note manual test limitations

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a68e8dc578832d86357a67384ff59c